### PR TITLE
[0.2] Add Laravel 5.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,13 @@ In your terminal:
 composer require novius/laravel-backpack-base-extended
 ```
 
-In `config/app.php`, replace
+Then, if you are on Laravel 5.4 (no need for Laravel 5.5 and higher), register the service provider to your `config/app.php` file:
 
 ```php
-Backpack\Base\BaseServiceProvider::class,
-```
-
-by
-
-```php
-Novius\Backpack\Base\BaseServiceProvider::class,
+'providers' => [
+    ...
+    Novius\Backpack\Base\BaseServiceProvider::class,
+];
 ```
 
 Launch these commands:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.0",
         "backpack/base": "^0.7",
-        "laravel/framework": ">=5.4"
+        "laravel/framework": "~5.4.0|~5.5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.5.0",
@@ -42,6 +42,13 @@
         "test" : [
             "phpunit"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Novius\\Backpack\\Base\\BaseServiceProvider"
+            ]
+        }
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
- Add package autodiscovery ;
- Breaking change: our Service Provider no longer extends original Backpack ServiceProvider : under Laravel 5.4, you have now to register both service provider in your config file.